### PR TITLE
Steammodded Support Fix

### DIFF
--- a/ko.lua
+++ b/ko.lua
@@ -3399,28 +3399,36 @@ return {
                 ["2"] = "Vampire Survivors",
                 ["3"] = "Slay the Spire",
                 ["4"] = "Potion Craft",
-                ["5"] = "Warframe"
+                ["5"] = "Warframe",
+                ["6"] = "Vault-Tec",
+                ["7"] = "Dead by Daylight",
             },
             Diamonds = {
                 ["1"] = "기본",
                 ["2"] = "데이브 더 다이버",
                 ["3"] = "Stardew Valley",
                 ["4"] = "Enter the Gungeon",
-                ["5"] = "1000xRESIST"
+                ["5"] = "1000xRESIST",
+                ["6"] = "문명 VII",
+                ["7"] = "Rust",
             },
             Hearts = {
                 ["1"] = "기본",
                 ["2"] = "Among Us",
                 ["3"] = "The Binding of Isaac",
                 ["4"] = "Cult of the Lamb",
-                ["5"] = "Divinity Original Sin 2"
+                ["5"] = "Divinity Original Sin 2",
+                ["6"] = "Critical Role",
+                ["7"] = "Bugsnax",
             },
             Spades = {
                 ["1"] = "기본",
                 ["2"] = "더 위쳐",
                 ["3"] = "Cyberpunk 2077",
                 ["4"] = "Shovel Knight",
-                ["5"] = "Don't Starve"
+                ["5"] = "Don't Starve",
+                ["6"] = "Assassin's Creed",
+                ["7"] = "Slay the Princess",
             },
         },
         dictionary = {

--- a/lovely.toml
+++ b/lovely.toml
@@ -1,7 +1,7 @@
 [manifest]
 version = "1.0.0"
 dump_lua = true
-priority = 0
+priority = -11
 
 [[patches]]
 [patches.copy]

--- a/utils.lua
+++ b/utils.lua
@@ -30,6 +30,10 @@ function apply_properkorean()
                 break
             end
         end
+        
+        if G and G.collab_credits == nil then
+          G.collab_credits = {}
+        end
     end
 end
 


### PR DESCRIPTION
- Steammodded에서 덱 사용자 수정 로드 시 nil을 로드하지 않게 하기 위해 크레딧 테이블을 사전 추가
- Steammodded 번역 중복 시 로드되지 않는 현상 방지를 위해 우선도를 -11로 설정